### PR TITLE
main: add newline to 'No errors found' message

### DIFF
--- a/cmd/trojansourcedetector/main.go
+++ b/cmd/trojansourcedetector/main.go
@@ -33,7 +33,7 @@ func main() {
 	if len(errs.Get()) > 0 {
 		os.Exit(1)
 	} else {
-		fmt.Printf("No errors found.")
+		fmt.Printf("No errors found.\n")
 	}
 }
 


### PR DESCRIPTION
## Please describe the change you are making

The 'success' message did not end in a newline character, causing unexpected
indentation of subsequent messages when this tool is used in a build
process.

## Your code will be released under [the Unlicense](LICENSE.md) into the public domain for everyone to use for any purpose. Are you in the position, and are you willing to release your code under this license?

Yes
